### PR TITLE
update transpilation target

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
     // Disabled because of https://github.com/Microsoft/TypeScript/issues/29172
     // "outDir": "dist",
 
-    "target": "es2019", // Node.js 8
+    "target": "ES2022", // Assuming nodejs 18 according to https://github.com/microsoft/TypeScript/wiki/Node-Target-Mapping
     "module": "commonjs",
     "moduleResolution": "node",
     "resolveJsonModule": true,


### PR DESCRIPTION
Je crois bien que tous les projets qui utilisent cette config ont migré vers node 18 et d'après ce mapping on peut mettre ES2022 en target : https://github.com/microsoft/TypeScript/wiki/Node-Target-Mapping